### PR TITLE
[PA-147] GetX 최초 controller 사용 시 fetch 오류 수정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,12 +54,12 @@ void main() async {
   Get.put(ItemCreateDetailController());
   Get.put(BuyerSearchController());
   Get.put(BuyerHomeController());
-  Get.put(BuyerProfileController());
-  Get.put(BuyerProfileEditController());
+  Get.lazyPut(() => BuyerProfileController());
+  Get.lazyPut(() => BuyerProfileEditController());
   Get.put(SellerHomeController());
   Get.put(SellerSearchController());
-  Get.put(SellerProfileController());
-  Get.put(SellerProfileEditController());
+  Get.lazyPut(() => SellerProfileController());
+  Get.lazyPut(() => SellerProfileEditController());
   Get.put(BuyerMessageController());
 
   await initializeDateFormatting();


### PR DESCRIPTION
- 최초 main에서 controller를 생성하여 사용하지 않는 controller가 생성되고, 바로 fetch하는 문제가 존재합니다.
- get.find를 사용하여 controller가 사용될 때에만 onInit 함수를 호출하여 fetch하도록 수정합니다.