### PR TITLE
[PA-199] 채팅창 로딩 버그 수정

### DIFF
--- a/lib/src/screens/buyer/message_detail_screen.dart
+++ b/lib/src/screens/buyer/message_detail_screen.dart
@@ -153,6 +153,7 @@ class MessageDetailScreen extends GetView<MessageController> {
       BoxDecoration boxDecoration, Function onTapAction) {
     ItemInfo? item = message.itemInfo;
     if (item == null) {
+      controller.fetchItemInfo(message);
       return CircularProgressIndicator();
     }
     return GestureDetector(


### PR DESCRIPTION
- 판매자 상태에서 채팅 리스트를 fetch하는 경우 잘 fetch되지 않고 계속 progress bar가 도는 문제가 발생합니다.
- 아이템이 없는 경우 동적으로 메세지를 fetch하도록 합니다.