### PR TITLE
[PA-256] 채팅 페이지 성능 이슈 해결

### DIFF
--- a/lib/src/controllers/message_controller.dart
+++ b/lib/src/controllers/message_controller.dart
@@ -39,7 +39,6 @@ class MessageController extends GetxService {
     chatRoomList.clear();
     chatRoomList.addAll(fetchedBuyerChatRoomList);
     chatRoomList.addAll(fetchedSellerChatRoomList);
-    await fetchItemInfoList();
     isLoading.value = false;
   }
 
@@ -240,14 +239,6 @@ class MessageController extends GetxService {
         break;
     }
     chatRoomList.refresh();
-  }
-
-  fetchItemInfoList() async {
-    for (final chatRoom in chatRoomList) {
-      for (final message in chatRoom.messageList) {
-        await fetchItemInfo(message);
-      }
-    }
   }
 
   isDifferentUserIndex(int index) {


### PR DESCRIPTION
- 앱에 최초 진입 시에 채팅 페이지의 모든 아이템 정보를 다 읽어들여 오류가 발생합니다.
- 채팅방에 진입 시에 아이템을 읽도록 합니다.