### PR TITLE
[PA-263] 채팅방 페이지네이션 적용

### DIFF
--- a/lib/src/models/message.dart
+++ b/lib/src/models/message.dart
@@ -91,6 +91,7 @@ class ChatRoom {
   final String opponentProfileImageUrl;
   late final bool isBuyerRoom;
   bool isRegistered;
+  bool hasMoreMessage = true;
 
   List<Message> messageList = <Message>[];
   List<Message> tempMessageList = <Message>[];

--- a/lib/src/repositories/message_repository.dart
+++ b/lib/src/repositories/message_repository.dart
@@ -87,6 +87,6 @@ class MessageRepository {
       Message message = Message.fromJson(data[i]);
       messageList.add(message);
     }
-    return messageList;
+    return messageList.reversed.toList();
   }
 }

--- a/lib/src/screens/buyer/message_detail_screen.dart
+++ b/lib/src/screens/buyer/message_detail_screen.dart
@@ -68,6 +68,9 @@ class MessageDetailScreen extends GetView<MessageController> {
         shrinkWrap: true,
         itemCount: messageList.length,
         itemBuilder: (context, index) {
+          if (controller.isLoadingScroll.value) {
+            return Center(child: RefreshProgressIndicator());
+          }
           return _messageWidget(messageList[index], index);
         },
       ),


### PR DESCRIPTION
- 기존에는 모든 채팅을 한번에 불러와 저장하여 데이터가 많아지는 경우 느린 로딩을 경험하게 되었습니다.
- 이는 한번에 많은 트래픽으로 인하여 느린 사용자 경험을 유발합니다.
- 페이지네이션 적용 및 스크롤 적용으로 채팅을 15개씩 호출하도록 합니다.