### PR TITLE
전시전 글자 튀어나오는 현상 수정

### DIFF
--- a/lib/app/ui/app/buyer/exhibition/widgets/exhibition_carousel_widget.dart
+++ b/lib/app/ui/app/buyer/exhibition/widgets/exhibition_carousel_widget.dart
@@ -63,7 +63,8 @@ _exhibitionCarouselItem(
             ClipRRect(
               borderRadius: BorderRadius.circular(16),
               child: CachedNetworkImage(
-                imageUrl: coverImage ?? 'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
+                imageUrl: coverImage ??
+                    'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
                 fit: BoxFit.cover,
                 width: Get.width * 0.8,
                 height: Get.height * 0.56,
@@ -75,13 +76,16 @@ _exhibitionCarouselItem(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    title,
-                    style: TextStyle(
-                      color: ColorPalette.white,
-                      fontWeight: FontWeight.w600,
-                      fontFamily: FontPalette.pretendard,
-                      fontSize: 18,
+                  SizedBox(
+                    width: Get.width * 0.6,
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: ColorPalette.white,
+                        fontWeight: FontWeight.w600,
+                        fontFamily: FontPalette.pretendard,
+                        fontSize: 18,
+                      ),
                     ),
                   ),
                   SizedBox(height: 10),

--- a/lib/app/ui/app/buyer/exhibition_detail/widgets/exhibition_widget.dart
+++ b/lib/app/ui/app/buyer/exhibition_detail/widgets/exhibition_widget.dart
@@ -11,7 +11,8 @@ exhibitionWidget() {
     children: [
       ClipRRect(
         child: CachedNetworkImage(
-          imageUrl: controller.exhibition.coverImage ?? 'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
+          imageUrl: controller.exhibition.coverImage ??
+              'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
           fit: BoxFit.cover,
           width: Get.width,
         ),
@@ -22,13 +23,16 @@ exhibitionWidget() {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              controller.exhibition.title,
-              style: TextStyle(
-                color: ColorPalette.white,
-                fontWeight: FontWeight.w600,
-                fontFamily: FontPalette.pretendard,
-                fontSize: 18,
+            SizedBox(
+              width: Get.width * 0.9,
+              child: Text(
+                controller.exhibition.title,
+                style: TextStyle(
+                  color: ColorPalette.white,
+                  fontWeight: FontWeight.w600,
+                  fontFamily: FontPalette.pretendard,
+                  fontSize: 18,
+                ),
               ),
             ),
             SizedBox(height: 10),

--- a/lib/app/ui/app/seller/exhibition/widgets/exhibition_carousel_widget.dart
+++ b/lib/app/ui/app/seller/exhibition/widgets/exhibition_carousel_widget.dart
@@ -60,7 +60,8 @@ _exhibitionCarouselItem(
             ClipRRect(
               borderRadius: BorderRadius.circular(16),
               child: CachedNetworkImage(
-                imageUrl: coverImage ?? 'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
+                imageUrl: coverImage ??
+                    'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
                 fit: BoxFit.cover,
                 width: Get.width * 0.8,
                 height: Get.height * 0.56,
@@ -72,13 +73,16 @@ _exhibitionCarouselItem(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    title,
-                    style: TextStyle(
-                      color: ColorPalette.white,
-                      fontWeight: FontWeight.w600,
-                      fontFamily: FontPalette.pretendard,
-                      fontSize: 18,
+                  SizedBox(
+                    width: Get.width * 0.6,
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: ColorPalette.white,
+                        fontWeight: FontWeight.w600,
+                        fontFamily: FontPalette.pretendard,
+                        fontSize: 18,
+                      ),
                     ),
                   ),
                   SizedBox(height: 10),

--- a/lib/app/ui/app/seller/exhibition_create_exhibition/widgets/exhibition_seller_input_widget.dart
+++ b/lib/app/ui/app/seller/exhibition_create_exhibition/widgets/exhibition_seller_input_widget.dart
@@ -34,7 +34,7 @@ Widget exhibitionSellerInputWidget() {
         child: TextField(
           onTapOutside: (event) =>
               FocusManager.instance.primaryFocus?.unfocus(),
-          maxLength: 46,
+          maxLength: 12,
           controller: controller.sellerNameController,
           decoration: InputDecoration(
             border: InputBorder.none,

--- a/lib/app/ui/app/seller/exhibition_create_exhibition/widgets/exhibition_title_input_widget.dart
+++ b/lib/app/ui/app/seller/exhibition_create_exhibition/widgets/exhibition_title_input_widget.dart
@@ -34,7 +34,7 @@ Widget exhibitionTitleInputWidget() {
         child: TextField(
           onTapOutside: (event) =>
               FocusManager.instance.primaryFocus?.unfocus(),
-          maxLength: 46,
+          maxLength: 30,
           controller: controller.exhibitionTitleController,
           decoration: InputDecoration(
             border: InputBorder.none,

--- a/lib/app/ui/app/seller/exhibition_create_seller/widgets/seller_introduction_editor_widget.dart
+++ b/lib/app/ui/app/seller/exhibition_create_seller/widgets/seller_introduction_editor_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:get/get.dart';
 
@@ -134,6 +135,16 @@ sellerIntroductionEditorWidget() {
                 textAlign: TextAlign.center,
                 controller: controller.sellerIntroductionController,
                 maxLines: 5,
+                inputFormatters: [
+                  TextInputFormatter.withFunction((oldValue, newValue) {
+                    int newLines = newValue.text.split('\n').length;
+                    if (newLines > 5) {
+                      return oldValue;
+                    } else {
+                      return newValue;
+                    }
+                  }),
+                ],
                 maxLength: 100,
                 decoration: InputDecoration(
                   hintText: '작가 소개를 입력해주세요.',

--- a/lib/app/ui/app/seller/exhibition_preview/widgets/exhibition_widget.dart
+++ b/lib/app/ui/app/seller/exhibition_preview/widgets/exhibition_widget.dart
@@ -10,7 +10,8 @@ exhibitionWidget() {
     children: [
       ClipRRect(
         child: CachedNetworkImage(
-          imageUrl: controller.exhibition.coverImage ?? 'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
+          imageUrl: controller.exhibition.coverImage ??
+              'https://leporem-art-media-dev.s3.ap-northeast-2.amazonaws.com/exhibitions/exhibition_cover_image/exhibition_default_cover_image.png',
           fit: BoxFit.cover,
           width: Get.width,
         ),
@@ -21,13 +22,16 @@ exhibitionWidget() {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              controller.exhibition.title,
-              style: TextStyle(
-                color: ColorPalette.white,
-                fontWeight: FontWeight.w600,
-                fontFamily: FontPalette.pretendard,
-                fontSize: 18,
+            SizedBox(
+              width: Get.width * 0.9,
+              child: Text(
+                controller.exhibition.title,
+                style: TextStyle(
+                  color: ColorPalette.white,
+                  fontWeight: FontWeight.w600,
+                  fontFamily: FontPalette.pretendard,
+                  fontSize: 18,
+                ),
               ),
             ),
             SizedBox(height: 10),


### PR DESCRIPTION
- 전시전 썸네일에서 제목이 튀어나오는 현상
![image](https://github.com/SW-Palindrome/Leporem-art-FE/assets/52454255/b10b7f28-b623-4b96-aa23-80be275975ba)



- 하단의 사진처럼 화면 비율에 맞춰 개행이 되도록 수정
![Simulator Screenshot - iPhone 14 - 2023-11-27 at 15 31 07](https://github.com/SW-Palindrome/Leporem-art-FE/assets/52454255/af957d35-4008-4aea-9804-6056b0c6005f)
